### PR TITLE
Change dev cluster URLs

### DIFF
--- a/kubeconfig
+++ b/kubeconfig
@@ -2,11 +2,11 @@ apiVersion: v1
 clusters:
 - cluster:
     insecure-skip-tls-verify: true
-    server: https://upp-k8s-dev-delivery-eu-api.ft.com
+    server: https://upp-k8s-dev-delivery-eu-api.upp.ft.com
   name: upp-k8s-dev-delivery-eu
 - cluster:
     insecure-skip-tls-verify: true
-    server: https://upp-k8s-dev-publish-eu-api.ft.com
+    server: https://upp-k8s-dev-publish-eu-api.upp.ft.com
   name: upp-k8s-dev-publish-eu
 - cluster:
     insecure-skip-tls-verify: true


### PR DESCRIPTION
The dev clusters have been migrated to the new domain (`*.upp.ft.com`). To access them the kubeconfig configuration have to change.